### PR TITLE
test/academic-year-use-case

### DIFF
--- a/__tests__/useCases/modules/academicYear/create/academicYearCreate.test.ts
+++ b/__tests__/useCases/modules/academicYear/create/academicYearCreate.test.ts
@@ -41,7 +41,7 @@ describe('AcademicYearCreateUseCase', () => {
 
     const input = requestMockFactory['invalid-year'].year
     const min = 1994
-    const max = 2023
+    const max = new Date().getFullYear()
 
     expect(spyOnValidatorStub).toHaveBeenCalledWith(input, min, max)
 

--- a/__tests__/useCases/modules/academicYear/update/academicYearUpdateUseCase.test.ts
+++ b/__tests__/useCases/modules/academicYear/update/academicYearUpdateUseCase.test.ts
@@ -44,7 +44,7 @@ describe('AcademicYearUpdateUseCase', () => {
 
     const input = requestMockFactory['invalid-year'].year
     const min = 1994
-    const max = 2023
+    const max = new Date().getFullYear()
 
     expect(spyOnValidatorStub).toHaveBeenCalledWith(input, min, max)
 

--- a/src/useCases/constants/errors/academicYear/index.ts
+++ b/src/useCases/constants/errors/academicYear/index.ts
@@ -2,7 +2,7 @@ export const ACADEMIC_YEAR_INVALID_NAME_ERROR_MESSAGE =
   'Name must be between 4 and 20 characters'
 
 export const ACADEMIC_YEAR_INVALID_YEAR_ERROR_MESSAGE =
-  'Year must be between 1994 and 2023'
+  'Year must be between {min} and {max}'
 
 export const ACADEMIC_YEAR_EXISTS_NAME_ERROR_MESSAGE =
   'Academic year already exists with that name'


### PR DESCRIPTION
## O que foi feito?

Correção dos testes academicYear use cases. O ano estava fixo 2023, como estamos em 2024 o teste estava falhando. foi adicionado para pegar o valor do ano atual, utilizando ´getFullYear()´

## Observações

Foi feito também alteração na mensagem de erro para deixar mais genérico, removendo os valores.

## Checklist

- [x] Fazer auto review, verifique cada arquivo, busque por erros e oportunidades de melhorar o código
- [ ] Linkar a issue que o PR se refere
- [ ] Verificar se todos os requisitos da issue foram completados
- [x] Se auto adicionar como `assignees`
- [ ] Verificar se não teve erro durante o check
- [x] Sincronizar branch do PR com `develop`
- [ ] Adicionar `d3vlopes` como `reviewers`
